### PR TITLE
FIX: save log from Throwable.printStackTrace

### DIFF
--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/file/FileLogger.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/file/FileLogger.kt
@@ -12,7 +12,6 @@ import quanti.com.kotlinlog.file.bundle.CircleLogBundle
 import quanti.com.kotlinlog.file.bundle.DayLogBundle
 import quanti.com.kotlinlog.file.bundle.StrictCircleLogBundle
 import quanti.com.kotlinlog.file.file.*
-import quanti.com.kotlinlog.utils.convertToLogCatString
 import quanti.com.kotlinlog.utils.getApplicationName
 import quanti.com.kotlinlog.utils.getFormattedNow
 import quanti.com.kotlinlog.utils.loga
@@ -81,7 +80,7 @@ class FileLogger(
 
         val sb = StringBuilder()
         sb.append(formattedString)
-        sb.append(t.convertToLogCatString())
+        sb.append(android.util.Log.getStackTraceString(t))
 
         val finalText = sb.toString()
 

--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/file/FileLogger.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/file/FileLogger.kt
@@ -89,7 +89,7 @@ class FileLogger(
                 CrashLogFile(
                         appCtx,
                         t.javaClass.simpleName,
-                        text == SECRET_CODE_UNHANDLED
+                        tag == SECRET_CODE_UNHANDLED
                 ).apply {
                     write(finalText)
                     closeOutputStream()

--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/utils/StringHelpers.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/utils/StringHelpers.kt
@@ -1,8 +1,8 @@
 package quanti.com.kotlinlog.utils
 
 import android.content.Context
-
-
+import java.io.PrintWriter
+import java.io.StringWriter
 
 
 /**
@@ -20,26 +20,11 @@ fun Context.getApplicationName(): String {
 
 fun Throwable.convertToLogCatString(): String {
 
+    val err = StringWriter()
+    this.printStackTrace(PrintWriter(err))
+
     val sb = StringBuilder()
-
-    sb.append(this.toString())
-    sb.append("\n")
-
-    this.stackTrace.forEach {
-        sb.append("\t\t\t\t")
-        if (it.isNativeMethod)
-            sb.append("\t")
-        sb.append(it.className)
-        sb.append(".")
-        sb.append(it.methodName)
-        sb.append("(")
-        sb.append(it.fileName)
-        sb.append(":")
-        sb.append(it.lineNumber.toString())
-        sb.append(")")
-        sb.append("\n")
-    }
-
+    sb.append(err)
     return sb.toString()
 }
 

--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/utils/StringHelpers.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/utils/StringHelpers.kt
@@ -18,16 +18,6 @@ fun Context.getApplicationName(): String {
     return str.replace(' ', '_')
 }
 
-fun Throwable.convertToLogCatString(): String {
-
-    val err = StringWriter()
-    this.printStackTrace(PrintWriter(err))
-
-    val sb = StringBuilder()
-    sb.append(err)
-    return sb.toString()
-}
-
 fun StackTraceElement.getClassNameWithoutPackage(): String {
 
     val indexOfLastDot = className.lastIndexOf('.')

--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/weblogger/WebLogger.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/weblogger/WebLogger.kt
@@ -1,7 +1,6 @@
 package quanti.com.kotlinlog.weblogger
 
 import quanti.com.kotlinlog.base.ILogger
-import quanti.com.kotlinlog.utils.convertToLogCatString
 import quanti.com.kotlinlog.weblogger.bundle.BaseWebLoggerBundle
 import quanti.com.kotlinlog.weblogger.bundle.RestLoggerBundle
 import quanti.com.kotlinlog.weblogger.bundle.WebSocketLoggerBundle
@@ -44,7 +43,7 @@ class WebLogger(private val bun: BaseWebLoggerBundle) : ILogger {
 
     override fun logThrowable(androidLogLevel: Int, tag: String, methodName: String, text: String, t: Throwable) {
         var message = "$tag/$methodName: $text/n"
-        message += t.convertToLogCatString()
+        message += android.util.Log.getStackTraceString(t)
 
         val entity = WebLoggerEntity(bun.sessionName, androidLogLevel, message)
         sender.send(entity)


### PR DESCRIPTION
Instead of build custom message use printStackTrace. It logs parent
"caused by" exceptions.