### PR TITLE
Feat/custom metadata

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation project(':kotlinlog')
 
     // RxJava
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.3'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.8'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }

--- a/app/src/main/java/quanti/com/kotlinlog3/MainActivity.kt
+++ b/app/src/main/java/quanti/com/kotlinlog3/MainActivity.kt
@@ -8,6 +8,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.SystemClock
 import android.support.annotation.IdRes
 import android.support.v4.app.ActivityCompat
 import android.support.v4.content.ContextCompat
@@ -21,6 +22,7 @@ import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
 import quanti.com.kotlinlog.Log
 import quanti.com.kotlinlog.android.AndroidLogger
+import quanti.com.kotlinlog.android.MetadataLogger
 import quanti.com.kotlinlog.base.LogLevel
 import quanti.com.kotlinlog.base.getLogLevel
 import quanti.com.kotlinlog.crashlytics.CrashlyticsLogger
@@ -34,6 +36,8 @@ import quanti.com.kotlinlog.weblogger.WebLogger
 import quanti.com.kotlinlog.weblogger.bundle.RestLoggerBundle
 import quanti.com.kotlinlog.weblogger.bundle.WebSocketLoggerBundle
 import quanti.com.kotlinlog.weblogger.rest.IServerActive
+import java.text.SimpleDateFormat
+import java.util.Date
 
 const val REQUEST = 98
 const val RANDOM_TEXT = "qwertyuiop"
@@ -187,6 +191,13 @@ class MainActivity : AppCompatActivity(), RadioGroup.OnCheckedChangeListener, IS
     }
 
     fun logMetadata_clicked(view: View) {
+        MetadataLogger.customMetadataLambda = {
+            val time = Date(System.currentTimeMillis())
+            val format = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+            val uptime = SystemClock.uptimeMillis()
+            listOf(Pair("CURRENT_TIME", format.format(time)),
+                    Pair("SYSTEM_UPTIME", uptime.toString()))
+        }
         Log.logMetadata(applicationContext)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.31'
     repositories {
         jcenter()
         mavenCentral()
@@ -11,7 +11,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 19 15:23:01 CET 2019
+#Mon May 27 09:46:56 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/kotlinlog/build.gradle
+++ b/kotlinlog/build.gradle
@@ -46,10 +46,6 @@ android {
         }
     }
 
-
-
-
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -83,7 +79,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation "org.mockito:mockito-core:2.25.0"
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation 'org.robolectric:robolectric:4.2.1'
 
 }
 

--- a/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/android/MetadataLogger.kt
+++ b/kotlinlog/src/main/kotlin/quanti/com/kotlinlog/android/MetadataLogger.kt
@@ -11,11 +11,17 @@ object MetadataLogger {
 
     private val logs = ArrayList<Pair<String, String>>()
 
+    var customMetadataLambda: ((Context) -> List<Pair<String, String>>)? = null
+
     fun getLogStrings(context: Context): String {
         logs.clear()
         fillArrayBuild()
         logs.add(Pair("", ""))
         fillArrayBuildConfig(context)
+        customMetadataLambda?.invoke(context)?.let {
+            logs.add(Pair("", ""))
+            logs.addAll(it)
+        }
         return createNiceString()
     }
 


### PR DESCRIPTION
allow custom metadata rows in MetadataLogger

- added lambda function which is invoked at the time of metadata string creation
- the lambda should return list of custom metadata pairs